### PR TITLE
Update profile availability line for Fall 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Voice-driven assistant focused on practical speech-to-task automation workflows.
 - ML Engineer / AI Engineer / Robotics Software Engineer roles  
 - Internship and full-time opportunities  
 - Collaborations in applied AI and intelligent systems
+- Fall 2026 opportunities and research-driven product teams
 
 ---
 


### PR DESCRIPTION
## Summary
- refine the Open To section with a concise availability line
- clarify interest in research-driven product teams

Related: #1